### PR TITLE
Update plugin for use with guard > 2.9

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,14 +2,3 @@ source 'http://rubygems.org'
 
 # Specify your gem's dependencies in guard-passenger.gemspec
 gemspec
-
-gem 'rake'
-require 'rbconfig'
-
-if RbConfig::CONFIG['target_os'] =~ /darwin/i
-  gem 'rb-fsevent', '>= 0.3.2'
-  gem 'growl', '~> 1.0.3'
-elsif RbConfig::CONFIG['target_os'] =~ /linux/i
-  gem 'rb-inotify', '>= 0.5.1'
-  gem 'libnotify', '~> 0.1.3'
-end

--- a/guard-passenger.gemspec
+++ b/guard-passenger.gemspec
@@ -12,15 +12,13 @@ Gem::Specification.new do |s|
   s.summary     = 'Guard gem for Passenger'
   s.description = 'Guard::Passenger automatically restarts Passenger when needed.'
 
-  s.required_rubygems_version = '>= 1.3.6'
-  s.rubyforge_project         = 'guard-passenger'
+  s.add_dependency 'guard', '~> 2.10.0'
 
-  s.add_dependency 'guard', '>= 1.1.0.beta '
-
-  s.add_development_dependency 'bundler',       '~> 1.1.3'
-  s.add_development_dependency 'rspec',         '~> 2.10.0'
-  s.add_development_dependency 'guard-rspec',   '~> 1.1.0'
-  s.add_development_dependency 'guard-bundler', '~> 1.0.0'
+  s.add_development_dependency 'rake'
+  s.add_development_dependency 'bundler',       '~> 1.6'
+  s.add_development_dependency 'rspec',         '~> 3.0'
+  s.add_development_dependency 'guard-rspec',   '~> 1.1'
+  s.add_development_dependency 'guard-bundler', '~> 2.0.0'
 
   s.files = Dir.glob('{lib}/**/*') + %w[LICENSE README.rdoc]
   s.require_path = 'lib'

--- a/lib/guard/passenger.rb
+++ b/lib/guard/passenger.rb
@@ -1,9 +1,9 @@
 require 'guard'
-require 'guard/guard'
+require 'guard/plugin'
 require 'rubygems'
 
 module Guard
-  class Passenger < Guard
+  class Passenger < Plugin
 
     autoload :Runner, 'guard/passenger/runner'
     autoload :Pinger, 'guard/passenger/pinger'
@@ -22,7 +22,7 @@ module Guard
     # = Guard methods =
     # =================
 
-    def initialize(watchers = [], options = {})
+    def initialize(options = {})
       super
 
       @standalone   = options[:standalone].nil? ? true : options[:standalone]

--- a/spec/guard/passenger/pinger_spec.rb
+++ b/spec/guard/passenger/pinger_spec.rb
@@ -4,7 +4,7 @@ describe Guard::Passenger::Pinger do
 
   describe '.ping' do
     before(:each) do
-      Net::HTTP.should_receive(:start).any_number_of_times.and_yield(@http_object = mock('request'))
+      Net::HTTP.should_receive(:start).at_least(1).times.and_yield(@http_object = double('request'))
     end
 
     after(:each) do
@@ -13,7 +13,7 @@ describe Guard::Passenger::Pinger do
 
     describe "default" do
       before(:each) do
-        @http_object.should_receive(:head).with('/').and_return(@http_response = mock('response'))
+        @http_object.should_receive(:head).with('/').and_return(@http_response = double('response'))
       end
 
       it "should ping '/'" do
@@ -55,7 +55,7 @@ describe Guard::Passenger::Pinger do
     describe "custom path" do
       context "not beginning with '/'" do
         before(:each) do
-          @http_object.should_receive(:head).with('/foo').and_return(@http_response = mock('response'))
+          @http_object.should_receive(:head).with('/foo').and_return(@http_response = double('response'))
           @http_response.should_receive(:is_a?).with(Net::HTTPServerError)
         end
 
@@ -68,7 +68,7 @@ describe Guard::Passenger::Pinger do
 
       context "not beginning with '/'" do
         before(:each) do
-          @http_object.should_receive(:head).with('/foo').and_return(@http_response = mock('response'))
+          @http_object.should_receive(:head).with('/foo').and_return(@http_response = double('response'))
           @http_response.should_receive(:is_a?).with(Net::HTTPServerError)
         end
 

--- a/spec/guard/passenger/runner_spec.rb
+++ b/spec/guard/passenger/runner_spec.rb
@@ -11,32 +11,32 @@ describe Guard::Passenger::Runner do
       it 'should start passenger in development environment on the port 3000' do
         subject.should_receive(:system).with('passenger start --daemonize').and_return(true)
         Guard::UI.should_receive(:info).with("Passenger standalone started.")
-        subject.start_passenger('--daemonize').should be_true
+        subject.start_passenger('--daemonize').should be true
       end
 
       it 'should start passenger in production environment on the port 3000' do
         subject.should_receive(:system).with('passenger start --daemonize --environment production').and_return(true)
         Guard::UI.should_receive(:info).with("Passenger standalone started.")
-        subject.start_passenger('--daemonize --environment production').should be_true
+        subject.start_passenger('--daemonize --environment production').should be true
       end
 
       it 'should start passenger in development environment on the port 1337' do
         subject.should_receive(:system).with('passenger start --port 1337 --daemonize').and_return(true)
         Guard::UI.should_receive(:info).with("Passenger standalone started.")
-        subject.start_passenger('--port 1337 --daemonize').should be_true
+        subject.start_passenger('--port 1337 --daemonize').should be true
       end
 
       it 'should start passenger under sudo if sudo option set' do
         subject.should_receive(:system).with('rvmsudo passenger start --port 80 --daemonize').and_return(true)
         Guard::UI.should_receive(:info).with("Passenger standalone started.")
-        quietly { subject.start_passenger('--port 80 --daemonize', 'rvmsudo').should be_true }
+        quietly { subject.start_passenger('--port 80 --daemonize', 'rvmsudo').should be true }
       end
 
       it 'should fail to start passenger in development environment on the port 1' do
         subject.should_receive(:system).with('passenger start --port 1 --daemonize').and_return(false)
         Guard::UI.should_receive(:error).with("Passenger standalone failed to start!")
         expect {
-          quietly { subject.start_passenger('--port 1 --daemonize').should be_false }
+          quietly { subject.start_passenger('--port 1 --daemonize').should be false }
         }.to throw_symbol(:task_has_failed)
       end
     end
@@ -50,7 +50,7 @@ describe Guard::Passenger::Runner do
         subject.should_not_receive(:system).with('passenger start --daemonize')
         Guard::UI.should_receive(:error).with("Passenger standalone is not installed. You need at least Passenger version >= 3.0.0.\nPlease run 'gem install passenger' or add it to your Gemfile.")
         expect {
-          quietly { subject.start_passenger('--daemonize').should be_false }
+          quietly { subject.start_passenger('--daemonize').should be false }
         }.to throw_symbol(:task_has_failed)
       end
     end
@@ -59,12 +59,12 @@ describe Guard::Passenger::Runner do
   describe '#passenger_standalone_installed?' do
     it 'should not have passenger >= 3 installed' do
       subject.should_receive(:gem).with("passenger", ">=3.0.0").and_raise(Gem::LoadError)
-      subject.passenger_standalone_installed?.should be_false
+      subject.passenger_standalone_installed?.should be false
     end
 
     it 'should have passenger >= 3 installed' do
       subject.should_receive(:gem).with("passenger", ">=3.0.0").and_return(true)
-      subject.passenger_standalone_installed?.should be_true
+      subject.passenger_standalone_installed?.should be true
     end
   end
 
@@ -116,7 +116,7 @@ describe Guard::Passenger::Runner do
       end
 
       it 'should return true if restart succeeds' do
-        subject.restart_passenger.should be_true
+        subject.restart_passenger.should be true
       end
     end
 
@@ -132,7 +132,7 @@ describe Guard::Passenger::Runner do
 
       it 'should return false if restart fails' do
         expect {
-          quietly { subject.restart_passenger.should be_false }
+          quietly { subject.restart_passenger.should be false }
         }.to throw_symbol(:task_has_failed)
       end
     end

--- a/spec/guard/passenger_spec.rb
+++ b/spec/guard/passenger_spec.rb
@@ -2,64 +2,80 @@ require 'spec_helper'
 
 describe Guard::Passenger do
 
+  let(:default) { instance_double("Guard::Group") }
+  let(:test) { instance_double("Guard::Group") }
+
+  let(:session) { instance_double("Guard::Internals::Session") }
+  let(:groups) { instance_double("Guard::Internals::Groups") }
+  let(:state) { instance_double("Guard::Internals::State") }
+
+  before do
+    allow(groups).to receive(:add).with(:default).and_return(default)
+    allow(groups).to receive(:add).with(:test).and_return(test)
+
+    allow(session).to receive(:groups).and_return(groups)
+    allow(state).to receive(:session).and_return(session)
+    allow(Guard).to receive(:state).and_return(state)
+  end
+
   describe 'options' do
     describe 'standalone' do
       it 'should be true by default' do
-        subject = Guard::Passenger.new([])
+        subject = Guard::Passenger.new()
         subject.should be_standalone
       end
 
       it 'should be true if set to true' do
-        subject = Guard::Passenger.new([], { :standalone => true })
+        subject = Guard::Passenger.new({ :standalone => true })
         subject.should be_standalone
       end
 
       it 'should be false if set so' do
-        subject = Guard::Passenger.new([], { :standalone => false })
+        subject = Guard::Passenger.new({ :standalone => false })
         subject.should_not be_standalone
       end
     end
 
     describe 'ping' do
       it 'should be false by default' do
-        subject = Guard::Passenger.new([])
-        subject.ping.should be_false
+        subject = Guard::Passenger.new()
+        subject.ping.should be_falsey
       end
 
       it 'should be false if set so' do
-        subject = Guard::Passenger.new([], { :ping => false })
-        subject.ping.should be_false
+        subject = Guard::Passenger.new({ :ping => false })
+        subject.ping.should be false
       end
 
       it 'should be true if set so' do
-        subject = Guard::Passenger.new([], { :ping => true })
+        subject = Guard::Passenger.new({ :ping => true })
         subject.ping.should == '/'
       end
 
       it 'should be true if set to "foo"' do
-        subject = Guard::Passenger.new([], { :ping => 'foo' })
+        subject = Guard::Passenger.new({ :ping => 'foo' })
         subject.ping.should == 'foo'
       end
     end
 
     describe 'sudo' do
       it 'should be blank by default' do
-        subject = Guard::Passenger.new([])
+        subject = Guard::Passenger.new()
         subject.sudo.should == ''
       end
 
       it 'should be blank if set to false' do
-        subject = Guard::Passenger.new([], { :sudo => false })
+        subject = Guard::Passenger.new({ :sudo => false })
         subject.sudo.should == ''
       end
 
       it 'should be "sudo" if set to true' do
-        subject = Guard::Passenger.new([], { :sudo => true })
+        subject = Guard::Passenger.new({ :sudo => true })
         subject.sudo.should == 'sudo'
       end
 
       it 'should be "rvmsudo" if set to "rvmsudo"' do
-        subject = Guard::Passenger.new([], { :sudo => 'rvmsudo' })
+        subject = Guard::Passenger.new({ :sudo => 'rvmsudo' })
         subject.sudo.should == 'rvmsudo'
       end
     end
@@ -67,46 +83,46 @@ describe Guard::Passenger do
 
   describe 'port' do
     it 'should be 3000 if not set' do
-      subject.should_receive(:cli_start).any_number_of_times.and_return('')
+      subject.should_receive(:cli_start).at_least(1).times.and_return('')
       subject.send(:port).should == '3000'
     end
 
     it 'should be 1337 if cli is set to -p 1337' do
-      subject.should_receive(:cli_start).any_number_of_times.and_return('-p 1337')
+      subject.should_receive(:cli_start).at_least(1).times.and_return('-p 1337')
       subject.send(:port).should == '1337'
     end
 
     it 'should be 1337 if cli is set to --port 1337' do
-      subject.should_receive(:cli_start).any_number_of_times.and_return('--port 1337')
+      subject.should_receive(:cli_start).at_least(1).times.and_return('--port 1337')
       subject.send(:port).should == '1337'
     end
   end
 
   describe 'address' do
     it 'should be 0.0.0.0 if not set' do
-      subject.should_receive(:cli_start).any_number_of_times.and_return('')
+      subject.should_receive(:cli_start).at_least(1).times.and_return('')
       subject.send(:address).should == '0.0.0.0'
     end
 
     it 'should be me.local if cli is set to -a me.local' do
-      subject.should_receive(:cli_start).any_number_of_times.and_return('-a me.local')
+      subject.should_receive(:cli_start).at_least(1).times.and_return('-a me.local')
       subject.send(:address).should == 'me.local'
     end
 
     it 'should be 1337 if cli is set to --address me.local' do
-      subject.should_receive(:cli_start).any_number_of_times.and_return('--address me.local')
+      subject.should_receive(:cli_start).at_least(1).times.and_return('--address me.local')
       subject.send(:address).should == 'me.local'
     end
   end
 
   describe 'pid-file' do
     it 'should be nil if not set' do
-      subject.should_receive(:cli_start).any_number_of_times.and_return('')
+      subject.should_receive(:cli_start).at_least(1).times.and_return('')
       subject.send(:pid_file).should == nil
     end
 
     it 'should be me.local if cli is set to --pid-file /usr/passenger.pid' do
-      subject.should_receive(:cli_start).any_number_of_times.and_return('--pid-file /usr/passenger.pid')
+      subject.should_receive(:cli_start).at_least(1).times.and_return('--pid-file /usr/passenger.pid')
       subject.send(:pid_file).should == '/usr/passenger.pid'
     end
   end
@@ -144,7 +160,7 @@ describe Guard::Passenger do
     end
 
     it 'should call `rvmsudo passenger start -p 80` command if sudo is set to "rvmsudo" and port is set to 80' do
-      subject = Guard::Passenger.new([], { :sudo => 'rvmsudo' })
+      subject = Guard::Passenger.new({ :sudo => 'rvmsudo' })
       subject.should_receive(:cli_start).and_return('--daemonize --port 80')
       Guard::Passenger::Runner.should_receive(:start_passenger).with('--daemonize --port 80', 'rvmsudo').and_return(true)
       subject.start
@@ -212,28 +228,28 @@ describe Guard::Passenger do
 
       it 'should return true if `touch tmp/restart.txt\' command succeeds' do
         Guard::Passenger::Runner.stub(:restart_passenger).and_return(true)
-        subject.send(method).should be_true
+        subject.send(method).should be true
       end
 
       it 'should return false if `touch tmp/restart.txt\' command fails' do
         Guard::Passenger::Runner.stub(:restart_passenger).and_return(false)
-        subject.send(method).should be_false
+        subject.send(method).should be false
       end
 
       it 'should ping localhost:3000/ if ping is set to true' do
-        subject = Guard::Passenger.new([], { :ping => true })
+        subject = Guard::Passenger.new({ :ping => true })
         Guard::Passenger::Pinger.should_receive(:ping).with('0.0.0.0', "3000", true, '/')
         subject.send(method)
       end
 
       it 'should ping localhost:3000/ if ping is set to true and notifications are disabled' do
-        subject = Guard::Passenger.new([], { :ping => true, :notification => false })
+        subject = Guard::Passenger.new({ :ping => true, :notification => false })
         Guard::Passenger::Pinger.should_receive(:ping).with('0.0.0.0', "3000", false, '/')
         subject.send(method)
       end
 
       it 'should ping localhost:3000/test if ping is set to true and notifications are disabled' do
-        subject = Guard::Passenger.new([], { :ping => '/test', :notification => false })
+        subject = Guard::Passenger.new({ :ping => '/test', :notification => false })
         Guard::Passenger::Pinger.should_receive(:ping).with('0.0.0.0', "3000", false, '/test')
         subject.send(method)
       end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -9,7 +9,6 @@ Dir["#{File.expand_path('..', __FILE__)}/support/**/*.rb"].each { |f| require f 
 puts "Please do not update/create files while tests are running."
 
 RSpec.configure do |config|
-  config.color_enabled = true
   config.filter_run :focus => true
   config.run_all_when_everything_filtered = true
 end


### PR DESCRIPTION
This commit makes changes to the gemspec, specs, and plugin
implementation to allow the gem to be used with guard version >= 2.9.0.
`Guard::Guard` has been deprecated for awhile and was removed as of
guard 2.9, this replaces subclassing that with subclassing
`Guard::Plugin`.
